### PR TITLE
Add web-configurable Signal settings with token protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+config.json

--- a/receipt_relay/config.py
+++ b/receipt_relay/config.py
@@ -1,6 +1,8 @@
 from pydantic_settings import BaseSettings
 from pydantic import Field
 from typing import Optional
+from pathlib import Path
+import json
 
 class Settings(BaseSettings):
     printer_vendor_id: str = Field('0x04B8', env='PRINTER_VENDOR_ID')
@@ -23,4 +25,25 @@ class Settings(BaseSettings):
     web_port: int = Field(8081, env='WEB_PORT')
     web_token: Optional[str] = Field(None, env='WEB_TOKEN')
 
-settings = Settings()
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
+
+
+def _load_settings() -> Settings:
+    data = {}
+    if CONFIG_PATH.exists():
+        data = json.loads(CONFIG_PATH.read_text())
+    return Settings(**data)
+
+
+settings = _load_settings()
+
+
+def save_settings(data: dict) -> None:
+    CONFIG_PATH.write_text(json.dumps(data, indent=2))
+
+
+def reload_settings() -> None:
+    """Reload settings from CONFIG_PATH, mutating the existing object."""
+    new_settings = _load_settings()
+    settings.__dict__.update(new_settings.__dict__)

--- a/receipt_relay/web/templates/config.html
+++ b/receipt_relay/web/templates/config.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Configuration</title>
+</head>
+<body>
+<h1>Configuration</h1>
+<form action="/config" method="post">
+    <label>SIGNAL_NUMBER</label><br>
+    <input type="text" name="signal_number" value="{{ config.signal_number or '' }}"><br>
+    <label>ALLOWED_SENDERS</label><br>
+    <input type="text" name="allowed_senders" value="{{ config.allowed_senders or '' }}"><br>
+    <label>SIGNAL_REST_URL</label><br>
+    <input type="text" name="signal_rest_url" value="{{ config.signal_rest_url }}"><br>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,20 +1,62 @@
-import sys, os
+import sys, os, importlib, json
 sys.path.append(os.path.abspath("."))
 from fastapi.testclient import TestClient
-from receipt_relay.web.main import app
+
+TOKEN = "secret"
+os.environ["WEB_TOKEN"] = TOKEN
+
+
+def get_client():
+    import receipt_relay.config as config
+    import receipt_relay.web.main as web
+    importlib.reload(config)
+    importlib.reload(web)
+    return TestClient(web.app), config
 
 
 def test_index():
-    client = TestClient(app)
+    client, _ = get_client()
     resp = client.get("/")
     assert resp.status_code == 200
     assert "Receipt Relay Test" in resp.text
 
 
 def test_print_text():
-    client = TestClient(app)
+    client, _ = get_client()
     resp = client.post("/print", data={"text": "hello"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["ok"] is True
     assert "job_id" in data
+
+
+def test_config_requires_token():
+    client, _ = get_client()
+    resp = client.get("/config")
+    assert resp.status_code == 401
+
+
+def test_config_load_and_update():
+    client, config = get_client()
+    headers = {"X-Token": TOKEN}
+
+    resp = client.get("/config", headers=headers)
+    assert resp.status_code == 200
+    assert "SIGNAL_NUMBER" in resp.text
+
+    resp = client.post(
+        "/config",
+        headers=headers,
+        data={
+            "signal_number": "+15551234567",
+            "allowed_senders": "+15550001111",
+            "signal_rest_url": "http://example.com",
+        },
+    )
+    assert resp.status_code == 200
+    assert config.CONFIG_PATH.exists()
+    data = json.loads(config.CONFIG_PATH.read_text())
+    assert data["signal_number"] == "+15551234567"
+    assert config.settings.signal_number == "+15551234567"
+    config.CONFIG_PATH.unlink()
+


### PR DESCRIPTION
## Summary
- Allow loading and saving settings from `config.json`
- Add `/config` endpoints with token auth to edit Signal settings
- Cover config editing in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b396a443a48330ba503b32610e22d6